### PR TITLE
move function to second arg of .then

### DIFF
--- a/lib/Jexl.js
+++ b/lib/Jexl.js
@@ -108,8 +108,8 @@ Jexl.prototype.getTransform = function(name) {
  *          - {Error|null} err: Present if an error occurred
  *          - {*} result: The result of the evaluation
  * @returns {Promise<*>} resolves with the result of the evaluation.  Note that
- *      if a callback is supplied, the returned promise will already have
- *      a '.catch' attached to it in order to pass the error to the callback.
+ *      if a callback is supplied, the returned promise will pass the error to
+ *      the callback.
  */
 Jexl.prototype.eval = function(expression, context, cb) {
 	if (typeof context === 'function') {
@@ -126,7 +126,7 @@ Jexl.prototype.eval = function(expression, context, cb) {
 		return valPromise.then(function(val) {
 			called = true;
 			setTimeout(cb.bind(null, null, val), 0);
-		}).catch(function(err) {
+		}, function(err) {
 			if (!called)
 				setTimeout(cb.bind(null, err), 0);
 		});


### PR DESCRIPTION
Very minor PR to conform fully to the A+ spec. Removes once instance of <code>Promise.prototype.catch</code> which is not part of the spec. Noticed this after upgrading to node v0.12.4.