### PR TITLE
Add support for arbitrary whitespace in expressions.

### DIFF
--- a/lib/Lexer.js
+++ b/lib/Lexer.js
@@ -210,16 +210,13 @@ Lexer.prototype._isNegative = function(tokens) {
  * A utility function to determine if a string consists of only space
  * characters.
  * @param {string} str A string to be tested
- * @returns {boolean} true if the string is empty or consists of only spaces;
+ * @returns {boolean} true if the string is empty or consists of only whitespace;
  *      false otherwise.
  * @private
  */
+var _whitespaceRegex = /^\s*$/;
 Lexer.prototype._isWhitespace = function(str) {
-	for (var i = 0; i < str.length; i++) {
-		if (str[i] != ' ')
-			return false;
-	}
-	return true;
+	return _whitespaceRegex.test(str);
 };
 
 /**

--- a/test/evaluator/Evaluator.js
+++ b/test/evaluator/Evaluator.js
@@ -160,4 +160,8 @@ describe('Evaluator', function() {
 		const e = new Evaluator(grammar);
 		return e.eval(toTree('"".length')).should.become(0);
 	});
+	it('should handle an expression with arbitrary whitespace', function() {
+		var e = new Evaluator(grammar);
+		return e.eval(toTree('(\t2\n+\n3) *\n4\n\r\n')).should.become(20);
+	});
 });

--- a/test/parser/Parser.js
+++ b/test/parser/Parser.js
@@ -136,6 +136,15 @@ describe('Parser', function() {
 			right: {type: 'Literal', value: 5}
 		});
 	});
+	it('should handle whitespace in an expression', function() {
+		inst.addTokens(lexer.tokenize('\t2\r\n+\n\r3\n\n'));
+		inst.complete().should.deep.equal({
+			type: 'BinaryExpression',
+			operator: '+',
+			left: {type: 'Literal', value: 2},
+			right: {type: 'Literal', value: 3}
+		});
+	});
 	it('should handle object literals', function() {
 		inst.addTokens(lexer.tokenize('{foo: "bar", tek: 1+2}'));
 		inst.complete().should.deep.equal({
@@ -424,4 +433,3 @@ describe('Parser', function() {
 		});
 	});
 });
-


### PR DESCRIPTION
This replaces the whitespace detection in the lexer to match any whitespace, rather than just spaces, which in turn allows for JEXL expressions with arbitrary whitespace in them, including newlines. I'm not entirely sure I added enough test coverage, but I also didn't want to just enumerate all the existing tests "but with newlines". Feel free to suggest more test cases you'd like to see. 

I saw that #3 adds multiline expressions, but bundles it with a bunch of other stuff that I'm not really interested in, and it seems like it'll be awhile before it lands. My hope is that this is a much smaller change that can land sooner, as multiline expressions would really be useful for our project's use of JEXL.

Thanks for writing such a neat library!